### PR TITLE
Adding aks-engine v0.31.3

### DIFF
--- a/automatic/aks-engine/aks-engine.nuspec
+++ b/automatic/aks-engine/aks-engine.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>aks-engine</id>
+    <version>0.31.3</version>
+    <packageSourceUrl>https://github.com/synax/chocolatey-packages</packageSourceUrl>
+    <owners>Stefan Henseler</owners>
+    <title>aks-engine</title>
+    <authors>Microsoft AKS Engine is supported by and built with a community of developers</authors>
+    <projectUrl>https://github.com/Azure/aks-engine</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/synax/chocolatey-packages/master/icons/acs-engine.jpg</iconUrl>
+    <docsUrl>https://github.com/Azure/aks-engine/blob/master/docs/README.md</docsUrl>
+    <copyright>(c) 2017 Microsoft Azure</copyright>
+    <licenseUrl>https://github.com/Azure/aks-engine/blob/master/LICENSE</licenseUrl>
+    <bugTrackerUrl>https://github.com/Azure/aks-engine/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/Azure/aks-engine</projectSourceUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>kubernetes azure container aks-engine</tags>
+    <summary>Azure Kubernetes Engine - a place for community to collaborate and build the best open Kubernetes infrastructure for Azure.</summary>
+    <description>The Azure Kubernetes Engine (aks-engine) generates ARM (Azure Resource Manager) templates for Kubernetes clusters on Microsoft Azure.</description>
+    <releaseNotes>https://github.com/Azure/aks-engine/releases</releaseNotes>
+  </metadata>
+  <files>
+       <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/automatic/aks-engine/tools/chocolateyInstall.ps1
+++ b/automatic/aks-engine/tools/chocolateyInstall.ps1
@@ -1,0 +1,15 @@
+﻿
+$packageName = 'aks-engine'
+$toolsDir =  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$tempDir = "$toolsDir\temp"
+
+$packageArgs = @{
+    PackageName    = $packageName
+    Url64bit       = 'https://github.com/Azure/aks-engine/releases/download/v0.31.3/aks-engine-v0.31.3-windows-amd64.zip'
+    Checksum64     = '3e066d99a1e969506dbae6de0941365f930906ccceba992c252c4c7c75776728'
+    ChecksumType64 = 'sha256'
+    UnzipLocation  = $toolsDir
+}
+
+# Download and unzip into a temp folder
+Install-ChocolateyZipPackage @packageArgs

--- a/automatic/aks-engine/update.ps1
+++ b/automatic/aks-engine/update.ps1
@@ -1,0 +1,36 @@
+import-module au -Force
+
+$releases = 'https://github.com/Azure/aks-engine/releases'
+$github = 'https://github.com'
+
+function global:au_SearchReplace {
+    @{
+        'tools\chocolateyInstall.ps1' = @{
+            "(^\s*Url64bit\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
+            "(^\s*Checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+        }
+     }
+}
+
+function global:au_GetLatest {
+    $ProgressPreference = 'SilentlyContinue'
+    $hash_check_file_path = "$pwd/aksengine.hashcheck"
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+
+    $re  = "aks-engine-.+windows-amd64.zip"
+    $url = $github + $($download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href)
+
+    $version = ($url -split '-' | Select-Object -Last 3 | Select-Object -First 1).TrimStart('v')
+
+    $wc = New-Object net.webclient
+    $wc.Downloadfile($url, $hash_check_file_path)
+    $checksum = Get-FileHash -Algorithm SHA256 -Path $hash_check_file_path #-InputStream ([System.IO.MemoryStream]::New($Content))
+    $checksum64 = $checksum.Hash.ToLower()
+
+    $Latest = @{ URL64 = "$url"; Version = $version; Checksum64 = $checksum64}
+
+    return $Latest
+}
+
+Update-Package -ChecksumFor none -Verbose


### PR DESCRIPTION
First, **thank you** for publishing the acs-engine packages to Chocolatey. It's been very helpful!

As you probably know, acs-engine is at the end of its lifetime and has been replaced by [aks-engine](https://github.com/Azure/aks-engine) which focuses on Kubernetes.

Would you be willing to publish the aks-engine packages too? I admit to being clueless about most of Chocolatey and Zappier and appveyor (but that didn't stop me from creating this copy-and-paste PR in hopes that it works).